### PR TITLE
Checking adjustResize range to handle adjustResize|stateHidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Change Log
-===
+==========
+
+Version 2.2.1 *(2019-01-21)*
+----------------------------
+
+- Added logic to handle softInputMode with keyboard state flags. (windowSoftInputMode="adjustResize|stateHidden" or similar values will not crash anymore and keyboard visibility changes will be detected properly)
+
 
 Version 2.2.0 *(2018-12-11)*
 ----------------------------

--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.java
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 
 import android.view.WindowManager;
+
 import net.yslibrary.android.keyboardvisibilityevent.util.UIUtil;
 
 /**
@@ -52,8 +53,9 @@ public class KeyboardVisibilityEvent {
         }
 
         int softInputMethod = activity.getWindow().getAttributes().softInputMode;
-        if(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE != softInputMethod &&
-            WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED != softInputMethod){
+        if (WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED != softInputMethod &&
+                (WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE > softInputMethod ||
+                        WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN <= softInputMethod)) {
             throw new IllegalArgumentException("Parameter:activity window SoftInputMethod is not ADJUST_RESIZE");
         }
 


### PR DESCRIPTION
This change is to handle scenarios where softInputMethod have other flags associated with it like `adjustResize|stateHidden` or `adjustResize|stateVisible`. It will still throw exceptions for softInputMethods like `adjustPan` or `adjust Nothing` or combination of these with state flags.
