### PR TITLE
Handling statusbar height issue

### DIFF
--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.kt
@@ -76,7 +76,7 @@ object KeyboardVisibilityEvent {
                 activityRoot.getWindowVisibleDisplayFrame(r)
 
                 val screenHeight = activityRoot.rootView.height
-                val heightDiff = screenHeight - r.height()  - getContentRoot(activity).top
+                val heightDiff = screenHeight - r.height()
 
                 val isOpen = heightDiff > screenHeight * KEYBOARD_MIN_HEIGHT_RATIO
 
@@ -109,7 +109,7 @@ object KeyboardVisibilityEvent {
         activityRoot.getWindowVisibleDisplayFrame(r)
 
         val screenHeight = activityRoot.rootView.height
-        val heightDiff = screenHeight - r.height()
+        val heightDiff = screenHeight - r.height() - getContentRoot(activity).top
 
         return heightDiff > screenHeight * KEYBOARD_MIN_HEIGHT_RATIO
     }

--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEvent.kt
@@ -76,7 +76,7 @@ object KeyboardVisibilityEvent {
                 activityRoot.getWindowVisibleDisplayFrame(r)
 
                 val screenHeight = activityRoot.rootView.height
-                val heightDiff = screenHeight - r.height()
+                val heightDiff = screenHeight - r.height()  - getContentRoot(activity).top
 
                 val isOpen = heightDiff > screenHeight * KEYBOARD_MIN_HEIGHT_RATIO
 
@@ -115,6 +115,10 @@ object KeyboardVisibilityEvent {
     }
 
     internal fun getActivityRoot(activity: Activity): View {
-        return (activity.findViewById<View>(android.R.id.content) as ViewGroup).getChildAt(0)
+        return getContentRoot(activity).getChildAt(0)
+    }
+
+    private fun getContentRoot(activity: Activity): ViewGroup {
+        return activity.findViewById(android.R.id.content)
     }
 }

--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/Unregistrar.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/Unregistrar.kt
@@ -11,7 +11,7 @@ import android.view.ViewTreeObserver
 interface Unregistrar {
 
     /**
-     * unregisters the [ViewTreeObserver.OnGlobalLayoutListener] and there by does provide any more callback to the [KeyboardVisibilityEventListener]
+     * unregisters the [ViewTreeObserver.OnGlobalLayoutListener] and there by does not provide any more callback to the [KeyboardVisibilityEventListener]
      */
     fun unregister()
 }


### PR DESCRIPTION
The idea here is to exclude the height of status bar and actionbar(if there is) from the height diff calculation. The `ContentFrameLayout`(with id android.R.id.content) starts below actionbar. So the top of the view should tell the height of Statusbar + Actionbar. Refer the uiautomator screenshot for view hierarchy.

<img width="1359" alt="Screenshot 2020-02-10 at 12 09 28 PM" src="https://user-images.githubusercontent.com/1777963/74127027-75018900-4bff-11ea-8e18-0e02f954584a.png">


Fixes #41 