### PR TITLE
Fix issue which causes a crash when lauching an activity after using …

### DIFF
--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/AutoActivityLifecycleCallback.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/AutoActivityLifecycleCallback.kt
@@ -12,7 +12,7 @@ abstract class AutoActivityLifecycleCallback internal constructor(
     private val targetActivity: Activity
 ) : Application.ActivityLifecycleCallbacks {
 
-    override fun onActivityCreated(activity: Activity, bundle: Bundle) {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
         // no-op
     }
 


### PR DESCRIPTION
If the ? is omitted, this will cause a crash when launching an activity: 

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: co.chatsdk.android.app, PID: 13075
    java.lang.RuntimeException: Unable to start activity ComponentInfo{co.chatsdk.android.app/com.karumi.dexter.DexterActivity}: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter bundle
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3430)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3614)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:86)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2199)
        at android.os.Handler.dispatchMessage(Handler.java:112)
        at android.os.Looper.loop(Looper.java:216)
        at android.app.ActivityThread.main(ActivityThread.java:7625)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
     Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter bundle
        at net.yslibrary.android.keyboardvisibilityevent.AutoActivityLifecycleCallback.onActivityCreated(Unknown Source:7)
        at android.app.Application.dispatchActivityCreated(Application.java:232)
        at android.app.Activity.onCreate(Activity.java:1121)
        at com.karumi.dexter.DexterActivity.onCreate(Unknown Source:0)
        at android.app.Activity.performCreate(Activity.java:7458)
        at android.app.Activity.performCreate(Activity.java:7448)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1286)
```