### PR TITLE
Kotlin 1.4.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.novoda:bintray-release:0.9.2' // https://github.com/novoda/bintray-release
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.33.0'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/ext.gradle
+++ b/ext.gradle
@@ -2,4 +2,5 @@ ext {
     bintrayUser = System.getenv("BINTRAY_USER")
     bintrayKey = System.getenv("BINTRAY_KEY")
     dryRun = (System.getenv("dryRun") == "true").toString()
+    kotlinVersion = "1.4.10"
 }

--- a/keyboardvisibilityevent/build.gradle
+++ b/keyboardvisibilityevent/build.gradle
@@ -21,7 +21,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
     implementation "androidx.lifecycle:lifecycle-runtime:2.2.0"
 }
 
@@ -30,16 +29,10 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-task dokkaJavadoc(type:org.jetbrains.dokka.gradle.DokkaTask) {
-    outputFormat = 'javadoc'
-    outputDirectory = "$buildDir/javadoc"
-    inputs.dir 'src/main/java'
-}
-
 // build a jar with javadoc
 task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc"
+    from "$buildDir/dokka/javadoc"
 }
 
 artifacts {

--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEventListener.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/KeyboardVisibilityEventListener.kt
@@ -3,6 +3,6 @@ package net.yslibrary.android.keyboardvisibilityevent
 /**
  * Created by yshrsmz on 15/03/17.
  */
-interface KeyboardVisibilityEventListener {
+fun interface KeyboardVisibilityEventListener {
     fun onVisibilityChanged(isOpen: Boolean)
 }

--- a/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/Unregistrar.kt
+++ b/keyboardvisibilityevent/src/main/java/net/yslibrary/android/keyboardvisibilityevent/Unregistrar.kt
@@ -8,7 +8,7 @@ import android.view.ViewTreeObserver
  * on 28/02/2017
  */
 
-interface Unregistrar {
+fun interface Unregistrar {
 
     /**
      * unregisters the [ViewTreeObserver.OnGlobalLayoutListener] and there by does not provide any more callback to the [KeyboardVisibilityEventListener]

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,5 @@ android {
 dependencies {
     implementation project(':keyboardvisibilityevent')
 //    implementation 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:3.0.0-RC1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 }


### PR DESCRIPTION
I upgraded to Kotlin 1.4.10 and marked interfaces for SAM conversion https://kotlinlang.org/docs/reference/whatsnew14.html#sam-conversions-for-kotlin-interfaces

I wanted to upgrade Gradle/AGP but it seems that novoda/bintray-release doesn't support Gradle 6.0+ https://github.com/novoda/bintray-release/issues/298
You might want to consider https://github.com/panpf/bintray-publish as suggested in aforementioned issue.